### PR TITLE
Added release names doc

### DIFF
--- a/process/README.md
+++ b/process/README.md
@@ -10,6 +10,9 @@ This folder contains the policies and procedures The FAIR Package Manager TSC us
 
 ## Roles & Responsibilities
 
+## Release Management
+- [Release Names](./release-names.md)
+
 ## Election Process
 - [Elections Folder](https://github.com/fairpm/tsc/tree/main/elections) - contains documentation and historic election results
 

--- a/process/release-names.md
+++ b/process/release-names.md
@@ -1,0 +1,60 @@
+# Release Names
+
+This document tracks the release names used for {detail}. Each release is assigned a unique cheese-themed codename following the pattern of `adjective-cheese`.
+
+## Release Name Registry
+
+| Release Name | Version | Release Date | Notes |
+|--------------|---------|--------------|-------|
+| bucolic-buffalo | | | |
+| creamy-cheddar | | | |
+| mellow-mozzarella | | | |
+| pungent-parmesan | | | |
+| gentle-gouda | | | |
+| rich-ricotta | | | |
+| funky-feta | | | |
+| sharp-stilton | | | |
+| aged-asiago | | | |
+| buttery-boursin | | | |
+| crumbly-camembert | | | |
+| delicate-derby | | | |
+| herbed-havarti | | | |
+| nutty-neufchatel | | | |
+| melty-manchego | | | |
+| zesty-zamorano | | | |
+| tangy-taleggio | | | |
+| silky-swiss | | | |
+| rustic-roquefort | | | |
+| peppy-provolone | | | |
+| mild-muenster | | | |
+| lively-limburger | | | |
+| elegant-emmental | | | |
+| gorgeous-gorgonzola | | | |
+| vintage-vacherin | | | |
+| fresh-fontina | | | |
+| creamy-colby | | | |
+| bold-bleu | | | |
+| mature-monterey-jack | | | |
+| chunky-cheshire | | | |
+| plush-pecorino | | | |
+| robust-raclette | | | |
+| savory-swiss | | | |
+| tangy-tilsit | | | |
+| mellow-mahon | | | |
+| divine-danbo | | | |
+| aged-appenzeller | | | |
+| bold-beaufort | | | |
+| creamy-caerphilly | | | |
+| delicious-double-gloucester | | | |
+| earthy-edam | | | |
+| fragrant-fontina | | | |
+| golden-gruyere | | | |
+| hearty-halloumi | | | |
+| intense-idiazabal | | | |
+| jumping-jarlsberg | | | |
+| keen-kashkaval | | | |
+| lovely-lancashire | | | |
+| marvelous-mimolette | | | |
+| notorious-neufchatel | | | |
+
+


### PR DESCRIPTION
Adds list of release names noted in #86 Note I did want to ask:

1. Is this the right spot for this document
2. I have a place holder for what this release name applies to, I'd like guidance on exactly what is included (for example I think it's beyond just a release of the fair-plugin )