### PR TITLE
Update release calendar with detailed cadence information

### DIFF
--- a/process/release-calendar.md
+++ b/process/release-calendar.md
@@ -1,7 +1,11 @@
 # Release Calendar
 
+The FAIR project follows a structured release cadence with three 16-week milestone cycles per year, followed by a 4-week reset period. The purpose of these named milestone releases is to help coordinate the many projects and working groups within FAIR, allowing FAIR's TSC to set major themes or objectives for each milestone, and have each WG and software project under its banner work toward those common goals.
+
+An 8-week cadence for release cycles is shown below as a typical but not mandated schedule. FAIR maintains multiple software projects to meet its objectives, and not all will follow this cadence, with some perhaps doing only one release per milestone, and others potentially more, particularly where smaller changes are deployed. These releases are generally indicated by version numbering, with semantic versioning recommended. Following FAIR's "Version 1.0" milestone, version numbers are not intended to remain synchronized between different software projects. An 8-week cadence for release cycles is intended as a typical but not mandated schedule. FAIR maintains multiple software projects to meet its objectives. Working groups responsible for each software release will adopt an appropriate cadence for the project that includes at lease one release per milestone. For example, AspireCloud follows a release-when-ready model, with small changes released often and larger ones on a planned schedule toward a named release.
+
 ## Overview
-The FAIR project follows a structured release cadence with three 16-week milestone cycles per year, followed by a 4-week reset period.
+The FAIR project follows a structured release cadence with three 16-week milestone cycles per year, followed by a 4-week reset period. The cadence for these milestones follows a formula based on ISO-8601 week numbers which ensures a "reset" period always begins in December and ends in early January.
 
 ## Key Terms
 - **MC** = Milestone Cycle (16 weeks each)


### PR DESCRIPTION
Expanded the release calendar section to clarify the release cadence and versioning strategy for the FAIR project.