### PR TITLE
Fix links in getting-started.md

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -6,8 +6,8 @@ We’re happy that you’re here and that you’d like to contribute to the proj
 
 ## 📌 Step 1: Read the Contribution Guidelines
 
-Start by reading our [main guide for contributors](/../contributing.md).
-This document outlines the code of conduct, the TSC structure, governance and voting, code signing, and other stuff you should know about the project. Before getting involved, it’s important that you read through our [Code of Conduct](/../code-of-conduct.md) as all contributors agree to follow it.
+Start by reading our [main guide for contributors](contributing.md).
+This document outlines the code of conduct, the TSC structure, governance and voting, code signing, and other stuff you should know about the project. Before getting involved, it’s important that you read through our [Code of Conduct](code-of-conduct.md) as all contributors agree to follow it.
 
 ---
 


### PR DESCRIPTION
The Github SPA app will munge URLs if it has to guess as the completion path. 

Using the simplest relative path tends to work best.

/../contributing.md often gets munged to https://github.com/fairpm/tsc/tree/contributing.md

tree is not a valid branch and new users will often get a 404.

Removing the leading /../ should work better as it will maintain the current branch (main).

When relative paths are required it is best to leave of the leading / and instead use ../<path>/file.md