### PR TITLE
Added "release-checklist.md" to the "process" folder thinking this can serve as a start for various projects' usage

### DIFF
--- a/process/release-checklist.md
+++ b/process/release-checklist.md
@@ -1,0 +1,101 @@
+# Checklist for a Release
+Comprehensive checklist for a release, from scoping, preparation, coding, day-of-release, and promotion.
+
+## Pre-Release Planning Phase
+
+### **Release Scope & Timing**
+
+- [ ]  Define release version number and target date
+- [ ]  Identify features, bug fixes, and security updates included
+- [ ]  Document breaking changes and deprecations
+- [ ]  Assess regulatory compliance requirements (CRA, export controls, etc.)
+
+### **Technical Preparation**
+
+- [ ]  Code freeze date established
+- [ ]  All planned features merged and tested
+- [ ]  Dependency updates reviewed and tested
+- [ ]  Security vulnerability scan completed
+- [ ]  License compliance verified
+
+## **Development & Testing Phase**
+
+**Code Quality**
+
+- [ ]  All tests passing (unit, integration, end-to-end)
+- [ ]  Code review completed for all changes
+- [ ]  Static analysis and linting passed
+- [ ]  Performance benchmarks met
+
+**Security & Compliance**
+
+- [ ]  SBOM (Software Bill of Materials) generated
+- [ ]  Vulnerability scanning completed (dependencies and code)
+- [ ]  Security assessment conducted for new features
+- [ ]  Export control classification reviewed if applicable
+
+## **Release Artifact Preparation**
+
+**Build & Package**
+
+- [ ]  Release builds created for all target platforms
+- [ ]  Checksums/signatures generated for artifacts
+- [ ]  Artifacts uploaded to distribution channels
+- [ ]  Container images built and tagged (if applicable)
+
+**Documentation**
+
+- [ ]  Release notes drafted and reviewed
+- [ ]  Changelog updated with all changes
+- [ ]  Upgrade/migration guide created (if needed)
+- [ ]  API documentation updated
+- [ ]  Security advisories prepared (if applicable)
+
+## **Pre-Release Verification**
+
+**Testing & Validation**
+
+- [ ]  Release candidate deployed to staging environment
+- [ ]  Smoke tests passed
+- [ ]  Upgrade path tested from previous versions
+- [ ]  Rollback procedure verified
+
+**Communications Preparation**
+
+- [ ]  Blog post/announcement drafted
+- [ ]  Social media posts prepared
+- [ ]  Email notifications to users/stakeholders drafted
+- [ ]  Community communications planned
+
+## **Release Execution**
+
+**Distribution**
+
+- [ ]  Artifacts published to all distribution channels
+- [ ]  Version tags created in repository
+- [ ]  Release branch created/updated
+- [ ]  Documentation site updated
+
+**Announcements**
+
+- [ ]  GitHub release published with notes
+- [ ]  Blog post published
+- [ ]  Social media announcements posted
+- [ ]  Email notifications sent
+- [ ]  Community forums/channels notified
+
+## **Post-Release**
+
+**Monitoring**
+
+- [ ]  Monitor for issues in first 24-48 hours
+- [ ]  Track adoption metrics
+- [ ]  Review feedback channels
+- [ ]  Emergency rollback plan ready
+
+**Follow-up**
+
+- [ ]  Retrospective meeting scheduled
+- [ ]  Update release checklist based on learnings
+- [ ]  Archive release documentation
+- [ ]  Plan next release cycle


### PR DESCRIPTION
This `release-checklist.md` located in `/process/` is a bit generic in scope & is organized into phases of a release, intending to cover a complete release lifecycle:

   1. **Pre-Release Planning Phase** - Release scope definition, timing, and technical preparation
   including compliance assessment needs
   2. **Development & Testing Phase** - Code quality checks, security scans, and compliance verification
   (SBOM generation)
   3. **Release Artifact Preparation** - Build process, packaging, and comprehensive documentation
   requirements
   4. **Pre-Release Verification** - Staging deployments, smoke tests, and communication preparation
   5. **Release Execution** - Distribution, tagging, and multi-channel announcement coordination
   6. **Post-Release** - Monitoring, feedback collection, and retrospective planning

The thinking is a version of this could be added to each project, revised slightly with that project's needs. The plugin might have different planning steps, different development & testing specifics, than "Beacon" or another project would. _Example: fair-plugin would want a development & testing step of "ensure plugin meets WordPress coding standards" check._

Each project's leads should draft a version of a release checklist for that project.

When a release is being planned, the checklist could be copied to an Issue for that release, and items checked-off as the release progresses. 

The idea is to serve as a helper, not a burdensome process. 