### PR TITLE
Reflect persistent `develop` branch

### DIFF
--- a/process/release-branching-strategy.md
+++ b/process/release-branching-strategy.md
@@ -12,18 +12,6 @@ This document defines the branching strategy used for FAIR project releases.
 
 ## Release Branch Workflow
 
-### Overview
-
-```mermaid
-flowchart LR
-    A[Create delete] --> B[Development & PRs]
-    B --> C[Testing & Validation]
-    C --> D[Merge to main]
-    D --> E[Automated release & deployment]
-    E --> F[Next release cycle]
-    F --> A
-```
-
 ### Workflow Steps
 
 1. **Create Develop Branches**


### PR DESCRIPTION
From discussion here, https://fair.slack.com/archives/C092THESN4F/p1767907470538189 consider 2 persistent branches, main and develop. 

Feature branches and hotfix branches would be deleted post-merge.

First pass, will likely need some cleanup.

Ping @bensternthal and @chuckadams 